### PR TITLE
species argument and switch argument species

### DIFF
--- a/R/geneWiseAnalysis.R
+++ b/R/geneWiseAnalysis.R
@@ -56,7 +56,9 @@ geneWiseAnalysis <- function(kexp, design=NULL, how=c("cpm","tpm"),
   }
 
   ## only ones supported for now (would be simple to expand, though)
-  species <- match.arg(species) ## NOT to be confused with KEGG species ID
+   species <- match.arg(species, c("Homo.sapiens",
+                                       "Mus.musculus",
+                                       "Rattus.norvegicus")) ## NOT to be confused with KEGG species ID
   commonName <- switch(species, 
                        Mus.musculus="mouse", 
                        Homo.sapiens="human",


### PR DESCRIPTION
The previous match.arg(species) was a typo because it was missing the second argument to match from the catalog.  so this fix requires a user to enter geneWiseAnalysis(kexp, ... species="Homo.sapiens")  ; user must specify species of interest.

this line  species <- match.arg(species, c("Homo.sapiens",
                                       "Mus.musculus",
                                       "Rattus.norvegicus"))

will then yank out the species.  *The technically correct way of doing this is with a hash table*