### PR TITLE
Output limma expression values, with Meta info

### DIFF
--- a/R/geneWiseAnalysis.R
+++ b/R/geneWiseAnalysis.R
@@ -10,6 +10,7 @@
 #' 
 #' @import edgeR 
 #' @import limma
+#' @import biomaRt
 #' @import ReactomePA 
 #' @import clusterProfiler
 #' @import Homo.sapiens
@@ -56,11 +57,14 @@ geneWiseAnalysis <- function(kexp, design=NULL, how=c("cpm","tpm"),
   }
 
   ## only ones supported for now (would be simple to expand, though)
-  species <- match.arg(species) ## NOT to be confused with KEGG species ID
+   species <- match.arg(species, c("Homo.sapiens",
+                                       "Mus.musculus",
+                                       "Rattus.norvegicus")) ## NOT to be confused with KEGG species ID
   commonName <- switch(species, 
                        Mus.musculus="mouse", 
                        Homo.sapiens="human",
                        Rattus.norvegicus="rat")
+
 
   message("Fitting bundles...")
 
@@ -75,42 +79,107 @@ geneWiseAnalysis <- function(kexp, design=NULL, how=c("cpm","tpm"),
   # library(species, character.only=TRUE) ## can ignore this now 
   # topGenes <- topGenes[topGenes %in% keys(get(species), "ENTREZID")]
 
-  ## overall
+   #for ReactomePA it is needed to have entrezGene id,  adding to res list
+  if (commonName=="human") {
+    speciesMart<-useMart("ensembl",dataset="hsapiens_gene_ensembl")
+     speciesSymbol<-"hgnc_symbol"  #hugo nomenclature human only 
+    }#human
+
+  if(commonName=="mouse"){
+   speciesMart<-useMart("ensembl",dataset="mmusculus_gene_ensembl")
+    speciesSymbol<-"mgi_symbol"
+    }#mouse
+  if (commonName=="rat"){
+   speciesMart<-useMart("ensembl",dataset="rnorvegicus_gene_ensembl")
+    speciesSymbol<-"mgi_symbol"  # mgi supports rat and mouse http://www.informatics.jax.org/mgihome/nomen/gene.shtml
+    }#rat
+ message("finding entrez IDs of top ensembl genes...") 
+res$entrezID<-getBM(filters="ensembl_gene_id",
+                    attributes=c("ensembl_gene_id","entrezgene"),
+                    values=topGenes, #fitBundles ensembl Gene Ids
+                    mart=speciesMart)
+
+  converted<-res$entrezID[which(!is.na(res$entrezID[,2])==TRUE),]
+entrezVector<-as.vector(converted[,2])
+ensemblVector<-converted[,1]
+
   message("Performing Reactome enrichment analysis...")
   message("Matching species...")
   library(species, character.only=TRUE) ## can ignore this now 
-  enrich <- topGenes[topGenes %in% keys(get(species), "ENTREZID")]
-  res$enriched <- enrichPathway(gene=enrich, 
+ # enrich <- topGenes[topGenes %in% keys(get(species), "ENTREZID")]
+
+  res$enriched <- enrichPathway(gene=converted[,2], 
                                 qvalueCutoff=p.cutoff, 
                                 readable=TRUE) 
 
-  #adding res$Figures list object for multiplotting  
+ #adding res$Figures list object for multiplotting  
   res$Figures <- list()
   res$Figures$barplot <- barplot(res$enriched, 
                                  showCategory=10, 
                                  title="Overall Reactome enrichment")
 
-  ## cluster profiling within Reactome and/or GO 
-  message("Performing clustered enrichment analysis...")
-  res$scaledExprs <- t(scale(t(res$voomed$E[ enrich, ])))
-  ## turns out it's pretty easy: there's an "up" cluster, and a "down" cluster
+ #limma is in terms of ensembl id
+     message("Performing clustered enrichment analysis...")
+  res$scaledExprs <- t(scale(t(res$voomed$E[ ensemblVector, ])))
+  
+  #finding scaled Expression in terms of entrez id
+   scaledConvertedID<-getBM(filters="ensembl_gene_id",
+                         attributes=c("ensembl_gene_id","entrezgene"),
+                         values=rownames(res$scaledExprs),
+                         mart=speciesMart)
+
+stopifnot(nrow(res$scaledExprs)==nrow(scaledConvertedID))
+#map the entrez ID to the matching ensembl score
+indx<-which(rownames(res$scaledExprs)==scaledConvertedID[,1])
+#map limma sclaed expression to ENTREZ
+rownames(res$scaledExprs)<-scaledConvertedID[indx,2]
+  
+  message("clustering scaled expression in terms of entrez id ... ")
   clust <- cutree(hclust(dist(res$scaledExprs), method="ward"), k=2)
   genes <- split(names(clust), clust)
-  names(genes) <- c("down", "up")
-  res$clusts <- compareCluster(geneCluster=genes, 
-                               fun="enrichPathway", 
+    names(genes) <- c("down","up")
+    
+ res$clusts <- compareCluster(geneCluster=genes, 
+                              fun="enrichPathway", 
                                qvalueCutoff=p.cutoff)
 
   #adding ggplot object for multiplotting
   res$Figures$clusts <- plot(res$clusts) ## saving into Figures list
 
-  #create a plot vector
-  #plots<-c("p1","p2")
 
-  #FIXME: don't do this, it's a huge mess and will produce unexpected results
-  #       instead, call the function on the res$object and plot that. 
-  # saveArtemisPlots(res, outName="geneWiseAnalysisJoined")
+ G_list<-getBM(filters="ensembl_gene_id",
+                         attributes=c("ensembl_gene_id","entrezgene",speciesSymbol),
+                         values=scaledConvertedID[,1],
+                         mart=speciesMart)
+  
+  
+  index<-vector()
+for(i in 1:nrow(converted)){
+index[i]<-which(rownames(res$top)==G_list[i,1])
+}#indexing converted
 
+limmad<-res$top[index,]
+limmad<-cbind(limmad,G_list[,2],G_list[,3],G_list[,1])
+colnames(limmad)[7]<-"entrez_id"
+colnames(limmad)[8]<-"gene_name"
+colnames(limmad)[9]<-"ensembl_id"
+
+#grab the meta data matching the ensembl gene ids from limma
+Index<-mcols(features(kexp))$gene_id %in% limmad[,9] 
+newFeatures<-mcols(features(kexp))[Index,]
+Features<-newFeatures[c(4,8:9)]
+uniqueFeatures<-Features[!duplicated(Features$gene_id),]
+limmad[,10]<-NA
+limmad[,11]<-NA
+colnames(limmad)[c(10:11)]<-c("gene_biotype","biotype_class")
+
+for(i in 1:nrow(limmad)){
+indx<-which(rownames(limmad)==uniqueFeatures$gene_id[i])
+limmad[indx,c(10:11)]<-cbind(uniqueFeatures$gene_biotype[i],uniqueFeatures$biotype_class[i])
+}# cbind biotype class to li
+  
+  res$limmaWithMeta<-limmad
+  
   ## up vs down genes
   ## enrichedGO <- list()
   ## enrichedRx <- list()


### PR DESCRIPTION
Here is a summary that was tested on arcolombo/artemis  RAM branch.  this worked for the beta- version testing.  The motivation was due to Kwasi's request of having the differential expression with the meta-information.  this required data handling between features of genomic ranges, and limma outputs.


the issue is stemming from an early development decision to keep outputs in terms of ensembl gene IDs.  In order to use Reactome, this requires a mapping via biomaRt in terms of entrez id.    

Summary:
---lines  81-101  perform   ensemblGene_ID -> entrez id  dependent on commonName derived from match.arg input from user.  this is standard and performed successfully from arcolombo/artemis ~ RAM. 
    -reactome is performed on the object converted[,2] which is all the non - na  entrez Ids.

---line 120  runs a scaled transformation of limma values, but these values are in terms of ensembl ID,  so ensemblVector, are all the corresponding entries with non-na  entrez ID.  


---lines 128-132  is over-coding in an attempt to protect the use of the "which" command.  here is the logic:
                      the ensemblVector is the first column of a data frame which stores all the non-NA   entrez ID mapped by biomaRt.  
                      each column ensemblVector and entrezVector has identical rows.  
                      limma is performed on ensemblVector created res$scaledExprs and outputs ensembl IDs, and uses the which command because dimensions match to create an index
                      line 123 converts the limma outputs to entrez with non-NA.
                      line 146 creates G_list that has human gene nomenclature
                      lines 156-181  create a merge between limma expression and meta information from features(kexp).

----Lines 156-181 could be omitted if deemed unnecessary.  However lines 81-141 perform reactome and necessary ensembl -> entrez mapping.